### PR TITLE
Add travis build file with test and golangci-lint aggressive garbage collection (GOGC=10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+go:
+  - stable
+env:
+  - GO111MODULE=on
+jobs:
+  include:
+    - stage: Test and lint
+      script:
+        - go test ./...
+        - GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
+        - GO111MODULE=on golangci-lint run --deadline 120s
+notifications:
+  slack:
+    secure: t03TPD1KQogKliNQ9yB1HGLIUcIiLIjsY/PVCkILBMXCXNuO28Yd9S+T4KkvNHds+HvzLTMVqN03/vdqubhtJb4HLmv5Wib18lRao3MOkeZEVbs3qGoEjgpWELJHIrF22bBxPm4tvGM8NDGHV2bgZuGszu7peEGRaJ8IhhpHlA1T3jgmfKCaJxvvxYxn0tPOLVGBdisDZT9JsfXEdf8CeiiyipwWq07w0M48BbqbqPUhfPlL325+SmDgkM+NY+FhMagqcme+F0JaosvAqvotLO/PzhyguCrm5q6hC7gnkIeJaYrPJeWLrIPABhtc62WR7fBkmTrrqSwppKcHSiwuiDsXbEBemxN5BsDE1r6L3DJvyCuhdwBVMjmT2ZZx0ABnf3TBBVmYEhuk4yORU1SS81SSv+PvouOaiHylIWV4Dw0tx7gMakcnZkGmLVt3pKXWuwwPMJG1LKPq4aNR0YgZ2xeBeaKBbxPlAeB3Awp9vJlkAz8egXk98IN6vMZaO26nIwUcMD81tRZe9WWSUk5f5epHG0A4w5BE9Jg2xFuvghNo2CY65cg3V3AsNgkzdNS7THGlgKZWvK4pyIbSQF8HBf3c4VHF0xB7F9Bm/zPTbu2u2uetjOJWI+06HQ48e00hgbfNc1YTo3lsb3mx3RDawGgwkZCR3ovaDjJNTbI59Xc=
+branches:
+  except:
+    - /(ux.+|ux)/
+cache:
+  directories:
+    - $GOPATH/pkg/mod/
+    - $HOME/.cache/go-build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       script:
         - go test ./...
         - GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
-        - GO111MODULE=on golangci-lint run --deadline 120s
+        - GOGC=10 GO111MODULE=on golangci-lint run --deadline 500s
 notifications:
   slack:
     secure: t03TPD1KQogKliNQ9yB1HGLIUcIiLIjsY/PVCkILBMXCXNuO28Yd9S+T4KkvNHds+HvzLTMVqN03/vdqubhtJb4HLmv5Wib18lRao3MOkeZEVbs3qGoEjgpWELJHIrF22bBxPm4tvGM8NDGHV2bgZuGszu7peEGRaJ8IhhpHlA1T3jgmfKCaJxvvxYxn0tPOLVGBdisDZT9JsfXEdf8CeiiyipwWq07w0M48BbqbqPUhfPlL325+SmDgkM+NY+FhMagqcme+F0JaosvAqvotLO/PzhyguCrm5q6hC7gnkIeJaYrPJeWLrIPABhtc62WR7fBkmTrrqSwppKcHSiwuiDsXbEBemxN5BsDE1r6L3DJvyCuhdwBVMjmT2ZZx0ABnf3TBBVmYEhuk4yORU1SS81SSv+PvouOaiHylIWV4Dw0tx7gMakcnZkGmLVt3pKXWuwwPMJG1LKPq4aNR0YgZ2xeBeaKBbxPlAeB3Awp9vJlkAz8egXk98IN6vMZaO26nIwUcMD81tRZe9WWSUk5f5epHG0A4w5BE9Jg2xFuvghNo2CY65cg3V3AsNgkzdNS7THGlgKZWvK4pyIbSQF8HBf3c4VHF0xB7F9Bm/zPTbu2u2uetjOJWI+06HQ48e00hgbfNc1YTo3lsb3mx3RDawGgwkZCR3ovaDjJNTbI59Xc=

--- a/pkg/bridge/service.go
+++ b/pkg/bridge/service.go
@@ -292,8 +292,5 @@ func (g *generator) writeDefaultValue(label string, dv interface{}, t px.Type, b
 }
 
 func (g *generator) skipPackage(name string) string {
-	if strings.HasPrefix(name, g.skipPrefix) {
-		name = name[len(g.skipPrefix):]
-	}
-	return name
+	return strings.TrimPrefix(name, g.skipPrefix)
 }

--- a/pkg/bridge/service_test.go
+++ b/pkg/bridge/service_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCreateService_metadata(t *testing.T) {
 	pcore.Do(func(c px.Context) {
-		s := bridge.CreateService(c, github.Provider().(*schema.Provider), "TerraformGithub", "github",
+		s := bridge.CreateService(c, github.Provider().(*schema.Provider), "Github",
 			&terraform.ResourceConfig{
 				Config: map[string]interface{}{},
 			})
@@ -35,7 +35,7 @@ func TestCreateService_metadata(t *testing.T) {
 
 func TestCreateService_typeset(t *testing.T) {
 	pcore.Do(func(c px.Context) {
-		s := bridge.CreateService(c, github.Provider().(*schema.Provider), "TerraformGithub", "github",
+		s := bridge.CreateService(c, github.Provider().(*schema.Provider), "Github",
 			&terraform.ResourceConfig{
 				Config: map[string]interface{}{},
 			})


### PR DESCRIPTION
This commit adds a `.travis.yaml` with units tests, and lint via `golangci-lint` specifying `GOGC=10` to aggressively garbage collect and avoid out of memory exceptions, as well as a long deadline for running the linter (`--deadline=500s`)