### PR TITLE
Handle nil Object values represented as an empty array

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform v0.11.11
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/lyraproj/issue v0.0.0-20190321123504-45f186b58f0e
-	github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05
+	github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6
 	github.com/lyraproj/servicesdk v0.0.0-20190403161359-5e01b5910a94
 	github.com/marstr/guid v1.1.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/lyraproj/pcore v0.0.0-20190320221415-6e1d1bd9c47d h1:RRTuRU3D5BUp4loi
 github.com/lyraproj/pcore v0.0.0-20190320221415-6e1d1bd9c47d/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05 h1:DHDepxY8viIusn1/vd3jrVz6NblNWzIZBAVWeFRUWYk=
 github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
+github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6 h1:vENugHAMnNCBqhUl8OMZEonJ4eEgsdP5RU3WiM4PiNI=
+github.com/lyraproj/pcore v0.0.0-20190406122651-bf67b7db25c6/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/puppet-evaluator v0.0.0-20190319215018-daa49117e01b/go.mod h1:EUN20EdlItpJBeaR7xVGBcOl463bGvW1sP/5exfODzw=
 github.com/lyraproj/puppet-parser v0.0.0-20190319214357-9cf036d14d08/go.mod h1:gMRi/vCBXe1nAq+CBZl1eNm8yCT32b3tRZH03yjecGQ=
 github.com/lyraproj/puppet-workflow v0.0.0-20190320115549-e9bceb46beee/go.mod h1:osdfBXzrxp5JyHN84bqnoO504/zNi52O95O1WZ2voNg=

--- a/pkg/bridge/marshall.go
+++ b/pkg/bridge/marshall.go
@@ -159,15 +159,23 @@ func convertValue(v px.Value, t px.Type) px.Value {
 	case *types.OptionalType:
 		v = convertValue(v, at.ContainedType())
 	case px.ObjectType:
-		if a, ok := v.(*types.Array); ok && a.Len() == 1 {
-			v = a.At(0)
+		if a, ok := v.(*types.Array); ok && a.Len() <= 1 {
+			if a.Len() == 1 {
+				v = a.At(0)
+			} else {
+				v = px.Undef
+			}
 		}
 		if h, ok := v.(*types.Hash); ok {
 			v = optObjToOneElementArray(h, at.AttributesInfo().Attributes())
 		}
 	case *types.StructType:
-		if a, ok := v.(*types.Array); ok && a.Len() == 1 {
-			v = a.At(0)
+		if a, ok := v.(*types.Array); ok && a.Len() <= 1 {
+			if a.Len() == 1 {
+				v = a.At(0)
+			} else {
+				v = px.Undef
+			}
 		}
 		ts := at.Elements()
 		if h, ok := v.(*types.Hash); ok {


### PR DESCRIPTION
Terraform uses an empty array to represent an undefined value when the
value is a Resource. Since this bridge removes the intermediate array,
the empty array must be converted to an Undef.